### PR TITLE
Update plugin

### DIFF
--- a/conf.php
+++ b/conf.php
@@ -10,7 +10,7 @@ $limits['nolimit'] = 0; // allow unlimited duration (=~ 100 years) with duration
 
 // path on domain where a symlink to share.php can be found
 // example: http://mydomain.com/share.php
-$downloadpath = '//'.$_SERVER['HTTP_HOST'].'/plugins/filemanager-share/share.php';
+$downloadpath = '//'.$_SERVER['HTTP_HOST'].'/rutorrent/plugins/filemanager-share/share.php';
 
 
 return ['limits' => $limits,

--- a/init.js
+++ b/init.js
@@ -1,26 +1,6 @@
 
 plugin.loadCSS('share');
 
-
-function copyTextToClipboard(text) {
-	var textArea = $("#flm-share-clipboard");
-
-	textArea.show();
-	textArea.val(text);
-	textArea.focus();
-	textArea.select();
-	var successful = false;
-	try {
-		successful = document.execCommand('copy');
-	} catch (err) {
-		console.log('Oops, unable to copy');
-	}
-
-	textArea.hide();
-
-	return successful;
-}
-
 var table = {
 
 	addEntries: function(data) {
@@ -54,13 +34,12 @@ var table = {
 
 			if(table.selCount === 1) {
 				theContextMenu.add([theUILang['flm_popup_fsh-view'], function() {
-					plugin.showDialog('fsh-view', theWebUI.getTable("fsh").rowdata[id].fmtdata);
+					plugin.showDialog('fsh-view', table.rowdata[id].fmtdata);
 
 				}]);
 
-				theContextMenu.add(['Show in File Manager', function() {
-					var file = theWebUI.getTable("fsh").getValueById(id, 'file');
-
+				theContextMenu.add([theUILang['flm_popup_fsh-view-fm'], function() {
+					var file = table.getValueById(id, 'file');
 					flm.showPath(flm.utils.basedir(file));
 				}]);
 
@@ -83,9 +62,9 @@ var table = {
 				} );
 			}]);
 			theContextMenu.add([CMENU_SEP]);
-			theContextMenu.add([theUILang.FScopylink,(table.selCount !== 1) ? null : function() {
-				var link = theWebUI.getTable("fsh").getValueById('_fsh_'+target, 'link');
-				copyTextToClipboard(link);
+			theContextMenu.add([theUILang.FScopylink, (table.selCount !== 1) ? null : function() {
+				var link = table.getValueById(id, 'link');
+				copyToClipboard(link);
 			}]);
 
 			theContextMenu.show();
@@ -119,10 +98,11 @@ var table = {
 	updateColumnNames: function() {
 		var table = theWebUI.getTable("fsh");
 
+		table.renameColumnById('file',theUILang.FSfile);
+		table.renameColumnById('downloads',theUILang.FSdnumb);
+		table.renameColumnById('created',theUILang.FScreated);
 		table.renameColumnById('time',theUILang.FSexpire);
-		table.renameColumnById('name',theUILang.FSfile);
 		table.renameColumnById('link',theUILang.FSdlink);
-
 	}
 };
 
@@ -134,10 +114,10 @@ table.create =  function () {
 		columns:
 			[
 				{ text: '',			width: "210px", id: "file",		type: TYPE_STRING },
-				{ text: 'Downloads',			width: "65px",	id: "downloads",		type: TYPE_NUMBER },
-				{ text: theUILang.Size,			width: "60px",	id: "size",		type: TYPE_NUMBER },
-				{ text: 'Created', 			width: "120px", 	id: "created",		type: TYPE_DATE, 	"align" : ALIGN_CENTER},
-				{ text: '', 			width: "120px", 	id: "time",		type: TYPE_STRING, 	"align" : ALIGN_CENTER},
+				{ text: '',			width: "65px",	id: "downloads",	type: TYPE_NUMBER },
+				{ text: theUILang.Size,		width: "60px",	id: "size",		type: TYPE_NUMBER },
+				{ text: '', 			width: "120px",	id: "created",		type: TYPE_DATE, 	"align" : ALIGN_CENTER},
+				{ text: '', 			width: "120px",	id: "time",		type: TYPE_STRING, 	"align" : ALIGN_CENTER},
 				{ text: '',			width: "310px",	id: "link",		type: TYPE_STRING }
 			],
 		container:	"FileShare",
@@ -151,9 +131,6 @@ table.create =  function () {
 var share = {
 
 	api: null,
-
-	downlink: '',
-	clip: {},
 
 	add: function (file, pass, duration) {
 
@@ -240,7 +217,7 @@ var share = {
 
 };
 
-plugin.setFileManagerMenuEntries = function (menu, path) {
+plugin.setFileManagerMenuEntries = function(menu, path) {
 
 	var pathIsDir = flm.utils.isDir(path);
 
@@ -262,8 +239,8 @@ plugin.setFileManagerMenuEntries = function (menu, path) {
 
 };
 
-plugin.showDialog = function(what, templateData)
-{
+plugin.showDialog = function(what, templateData) {
+
 	var dialogs = flm.ui.getDialogs();
 	dialogs.forms[what].options=  {
 			//	public_endpoint: plugin.config.public_endpoint,
@@ -301,8 +278,7 @@ plugin.setUI = function(flmUi) {
 
 	window.flm.ui.browser.onSetEntryMenu(plugin.setFileManagerMenuEntries);
 
-
-	flm.views.getView(viewsPath + '/' +'table-header',{apiUrl: flm.api.endpoint},
+	flm.views.getView(viewsPath + 'table-header',{apiUrl: flm.api.endpoint},
 		function (view) {
 
 			$('#FileShare').prepend(view);
@@ -315,18 +291,14 @@ plugin.setUI = function(flmUi) {
 
 		}
 	);
-
 	plugin.renameTab("FileShare",theUILang.FSshow);
-	table.updateColumnNames()
+	table.updateColumnNames();
 };
-
-
 
 plugin.flmConfig = theWebUI.config;
 theWebUI.config = function(data) {
-
-		table.create();
-		plugin.flmConfig.call(this,data);
+	table.create();
+	plugin.flmConfig.call(this,data);
 };
 
 plugin.onShow = theTabs.onShow;

--- a/lang/cs.js
+++ b/lang/cs.js
@@ -1,14 +1,18 @@
 theUILang['flm_popup_flm-create-share'] =   'Create file share link';
 theUILang['flm_popup_fsh-view'] =   'View details';
+theUILang['flm_popup_fsh-view-fm'] =   'Show in File Manager';
 
 theUILang.FSshow		= 'File Share';
+theUILang.FSaddnew		= 'New share';
 theUILang.FSdel			= 'Delete link(s)';
 theUILang.FSdelmsg		= 'Do you really want to delete the selected items?';
 theUILang.FSvdur		= 'Please enter a valid duration';
 theUILang.FSfile		= 'File';
 theUILang.FSexpire		= 'Expire';
 theUILang.FSpassword		= 'Password';
+theUILang.FScreated		= 'Creation date';
 theUILang.FSdlink		= 'Download link';
+theUILang.FSdnumb		= 'Number of downloads';
 theUILang.FSdhours		= 'Duration (hours)';
 theUILang.FSadd			= 'Add';
 theUILang.FSedit		= 'Edit';
@@ -19,4 +23,5 @@ theUILang.FScopylink		= 'Copy link';
 theUILang.FSmaxdur		= 'Maximum allowed duration is:';
 theUILang.FSnolimit		= '[No limit is allowed: 0]';
 theUILang.FSnolimitoff		= 'No limit is not allowed';
+
 thePlugins.get("filemanager-share").langLoaded();

--- a/lang/da.js
+++ b/lang/da.js
@@ -1,14 +1,18 @@
 theUILang['flm_popup_flm-create-share'] =   'Create file share link';
 theUILang['flm_popup_fsh-view'] =   'View details';
+theUILang['flm_popup_fsh-view-fm'] =   'Show in File Manager';
 
 theUILang.FSshow		= 'File Share';
+theUILang.FSaddnew		= 'New share';
 theUILang.FSdel			= 'Delete link(s)';
 theUILang.FSdelmsg		= 'Do you really want to delete the selected items?';
 theUILang.FSvdur		= 'Please enter a valid duration';
 theUILang.FSfile		= 'File';
 theUILang.FSexpire		= 'Expire';
 theUILang.FSpassword		= 'Password';
+theUILang.FScreated		= 'Creation date';
 theUILang.FSdlink		= 'Download link';
+theUILang.FSdnumb		= 'Number of downloads';
 theUILang.FSdhours		= 'Duration (hours)';
 theUILang.FSadd			= 'Add';
 theUILang.FSedit		= 'Edit';
@@ -19,4 +23,5 @@ theUILang.FScopylink		= 'Copy link';
 theUILang.FSmaxdur		= 'Maximum allowed duration is:';
 theUILang.FSnolimit		= '[No limit is allowed: 0]';
 theUILang.FSnolimitoff		= 'No limit is not allowed';
+
 thePlugins.get("filemanager-share").langLoaded();

--- a/lang/de.js
+++ b/lang/de.js
@@ -1,14 +1,18 @@
 theUILang['flm_popup_flm-create-share'] =   'Create file share link';
 theUILang['flm_popup_fsh-view'] =   'View details';
+theUILang['flm_popup_fsh-view-fm'] =   'Show in File Manager';
 
 theUILang.FSshow		= 'File Share';
+theUILang.FSaddnew		= 'New share';
 theUILang.FSdel			= 'Delete link(s)';
 theUILang.FSdelmsg		= 'Do you really want to delete the selected items?';
 theUILang.FSvdur		= 'Please enter a valid duration';
 theUILang.FSfile		= 'File';
 theUILang.FSexpire		= 'Expire';
 theUILang.FSpassword		= 'Password';
+theUILang.FScreated		= 'Creation date';
 theUILang.FSdlink		= 'Download link';
+theUILang.FSdnumb		= 'Number of downloads';
 theUILang.FSdhours		= 'Duration (hours)';
 theUILang.FSadd			= 'Add';
 theUILang.FSedit		= 'Edit';
@@ -19,4 +23,5 @@ theUILang.FScopylink		= 'Copy link';
 theUILang.FSmaxdur		= 'Maximum allowed duration is:';
 theUILang.FSnolimit		= '[No limit is allowed: 0]';
 theUILang.FSnolimitoff		= 'No limit is not allowed';
+
 thePlugins.get("filemanager-share").langLoaded();

--- a/lang/el.js
+++ b/lang/el.js
@@ -1,14 +1,18 @@
 theUILang['flm_popup_flm-create-share'] =   'Create file share link';
 theUILang['flm_popup_fsh-view'] =   'View details';
+theUILang['flm_popup_fsh-view-fm'] =   'Show in File Manager';
 
 theUILang.FSshow		= 'File Share';
+theUILang.FSaddnew		= 'New share';
 theUILang.FSdel			= 'Delete link(s)';
 theUILang.FSdelmsg		= 'Do you really want to delete the selected items?';
 theUILang.FSvdur		= 'Please enter a valid duration';
 theUILang.FSfile		= 'File';
 theUILang.FSexpire		= 'Expire';
 theUILang.FSpassword		= 'Password';
+theUILang.FScreated		= 'Creation date';
 theUILang.FSdlink		= 'Download link';
+theUILang.FSdnumb		= 'Number of downloads';
 theUILang.FSdhours		= 'Duration (hours)';
 theUILang.FSadd			= 'Add';
 theUILang.FSedit		= 'Edit';
@@ -19,4 +23,5 @@ theUILang.FScopylink		= 'Copy link';
 theUILang.FSmaxdur		= 'Maximum allowed duration is:';
 theUILang.FSnolimit		= '[No limit is allowed: 0]';
 theUILang.FSnolimitoff		= 'No limit is not allowed';
+
 thePlugins.get("filemanager-share").langLoaded();

--- a/lang/en.js
+++ b/lang/en.js
@@ -1,14 +1,18 @@
 theUILang['flm_popup_flm-create-share'] =   'Create file share link';
 theUILang['flm_popup_fsh-view'] =   'View details';
+theUILang['flm_popup_fsh-view-fm'] =   'Show in File Manager';
 
 theUILang.FSshow		= 'File Share';
+theUILang.FSaddnew		= 'New share';
 theUILang.FSdel			= 'Delete link(s)';
 theUILang.FSdelmsg		= 'Do you really want to delete the selected items?';
 theUILang.FSvdur		= 'Please enter a valid duration';
 theUILang.FSfile		= 'File';
 theUILang.FSexpire		= 'Expire';
 theUILang.FSpassword		= 'Password';
+theUILang.FScreated		= 'Creation date';
 theUILang.FSdlink		= 'Download link';
+theUILang.FSdnumb		= 'Number of downloads';
 theUILang.FSdhours		= 'Duration (hours)';
 theUILang.FSadd			= 'Add';
 theUILang.FSedit		= 'Edit';

--- a/lang/es.js
+++ b/lang/es.js
@@ -1,14 +1,18 @@
 theUILang['flm_popup_flm-create-share'] =   'Create file share link';
 theUILang['flm_popup_fsh-view'] =   'View details';
+theUILang['flm_popup_fsh-view-fm'] =   'Show in File Manager';
 
 theUILang.FSshow		= 'File Share';
+theUILang.FSaddnew		= 'New share';
 theUILang.FSdel			= 'Delete link(s)';
 theUILang.FSdelmsg		= 'Do you really want to delete the selected items?';
 theUILang.FSvdur		= 'Please enter a valid duration';
 theUILang.FSfile		= 'File';
 theUILang.FSexpire		= 'Expire';
 theUILang.FSpassword		= 'Password';
+theUILang.FScreated		= 'Creation date';
 theUILang.FSdlink		= 'Download link';
+theUILang.FSdnumb		= 'Number of downloads';
 theUILang.FSdhours		= 'Duration (hours)';
 theUILang.FSadd			= 'Add';
 theUILang.FSedit		= 'Edit';
@@ -19,4 +23,5 @@ theUILang.FScopylink		= 'Copy link';
 theUILang.FSmaxdur		= 'Maximum allowed duration is:';
 theUILang.FSnolimit		= '[No limit is allowed: 0]';
 theUILang.FSnolimitoff		= 'No limit is not allowed';
+
 thePlugins.get("filemanager-share").langLoaded();

--- a/lang/fi.js
+++ b/lang/fi.js
@@ -1,14 +1,18 @@
 theUILang['flm_popup_flm-create-share'] =   'Create file share link';
 theUILang['flm_popup_fsh-view'] =   'View details';
+theUILang['flm_popup_fsh-view-fm'] =   'Show in File Manager';
 
 theUILang.FSshow		= 'File Share';
+theUILang.FSaddnew		= 'New share';
 theUILang.FSdel			= 'Delete link(s)';
 theUILang.FSdelmsg		= 'Do you really want to delete the selected items?';
 theUILang.FSvdur		= 'Please enter a valid duration';
 theUILang.FSfile		= 'File';
 theUILang.FSexpire		= 'Expire';
 theUILang.FSpassword		= 'Password';
+theUILang.FScreated		= 'Creation date';
 theUILang.FSdlink		= 'Download link';
+theUILang.FSdnumb		= 'Number of downloads';
 theUILang.FSdhours		= 'Duration (hours)';
 theUILang.FSadd			= 'Add';
 theUILang.FSedit		= 'Edit';
@@ -19,4 +23,5 @@ theUILang.FScopylink		= 'Copy link';
 theUILang.FSmaxdur		= 'Maximum allowed duration is:';
 theUILang.FSnolimit		= '[No limit is allowed: 0]';
 theUILang.FSnolimitoff		= 'No limit is not allowed';
+
 thePlugins.get("filemanager-share").langLoaded();

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -1,22 +1,27 @@
-﻿theUILang['flm_popup_flm-create-share'] =   'Create file share link';
-theUILang['flm_popup_fsh-view'] =   'View details';
+theUILang['flm_popup_flm-create-share'] =   'Créer un lien de partage';
+theUILang['flm_popup_fsh-view'] =   'Voir les détails';
+theUILang['flm_popup_fsh-view-fm'] =   'Voir dans le Gestionnaire de fichiers';
 
-theUILang.FSshow		= 'File Share';
+﻿theUILang.FSshow		= 'Partage de fichiers';
+theUILang.FSaddnew		= 'Nouveau partage';
 theUILang.FSdel			= 'Supprimer le(s) liens(s)';
 theUILang.FSdelmsg		= 'Voulez-vous réellement supprimer ces éléments ?';
 theUILang.FSvdur		= 'Veuillez entrer une durée valide';
-theUILang.FSfile		= 'Fichier ';
-theUILang.FSexpire		= 'Expire';
-theUILang.FSpassword		= 'Mot de passe ';
+theUILang.FSfile		= 'Fichier';
+theUILang.FSexpire		= 'Date d\'expiration';
+theUILang.FSpassword		= 'Mot de passe';
+theUILang.FScreated		= 'Date de création';
 theUILang.FSdlink		= 'Lien de téléchargement';
-theUILang.FSdhours		= 'Durée (heure) ';
+theUILang.FSdnumb		= 'Nombre de téléchargements';
+theUILang.FSdhours		= 'Durée (heure)';
 theUILang.FSadd			= 'Ajouter';
 theUILang.FSedit		= 'Éditer';
-theUILang.FSshare		= 'Partager...';
+theUILang.FSshare		= 'Créer un lien de partage';
 theUILang.FSlinkcreate		= 'Lien de téléchargement créé';
 theUILang.FSlinkedit		= 'Lien de téléchargement édité';
 theUILang.FScopylink		= 'Copier le lien';
 theUILang.FSmaxdur		= 'Durée maxi autorisée est :';
 theUILang.FSnolimit		= '[Pas de limite est autorisée : 0]';
 theUILang.FSnolimitoff		= 'Durée illimitée n\'est pas autorisée';
+
 thePlugins.get("filemanager-share").langLoaded();

--- a/lang/hu.js
+++ b/lang/hu.js
@@ -1,14 +1,18 @@
 theUILang['flm_popup_flm-create-share'] =   'Create file share link';
 theUILang['flm_popup_fsh-view'] =   'View details';
+theUILang['flm_popup_fsh-view-fm'] =   'Show in File Manager';
 
 theUILang.FSshow		= 'File Share';
+theUILang.FSaddnew		= 'New share';
 theUILang.FSdel			= 'Delete link(s)';
 theUILang.FSdelmsg		= 'Do you really want to delete the selected items?';
 theUILang.FSvdur		= 'Please enter a valid duration';
 theUILang.FSfile		= 'File';
 theUILang.FSexpire		= 'Expire';
 theUILang.FSpassword		= 'Password';
+theUILang.FScreated		= 'Creation date';
 theUILang.FSdlink		= 'Download link';
+theUILang.FSdnumb		= 'Number of downloads';
 theUILang.FSdhours		= 'Duration (hours)';
 theUILang.FSadd			= 'Add';
 theUILang.FSedit		= 'Edit';
@@ -19,4 +23,5 @@ theUILang.FScopylink		= 'Copy link';
 theUILang.FSmaxdur		= 'Maximum allowed duration is:';
 theUILang.FSnolimit		= '[No limit is allowed: 0]';
 theUILang.FSnolimitoff		= 'No limit is not allowed';
+
 thePlugins.get("filemanager-share").langLoaded();

--- a/lang/it.js
+++ b/lang/it.js
@@ -1,14 +1,18 @@
 theUILang['flm_popup_flm-create-share'] =   'Create file share link';
 theUILang['flm_popup_fsh-view'] =   'View details';
+theUILang['flm_popup_fsh-view-fm'] =   'Show in File Manager';
 
 theUILang.FSshow		= 'File Share';
+theUILang.FSaddnew		= 'New share';
 theUILang.FSdel			= 'Delete link(s)';
 theUILang.FSdelmsg		= 'Do you really want to delete the selected items?';
 theUILang.FSvdur		= 'Please enter a valid duration';
 theUILang.FSfile		= 'File';
 theUILang.FSexpire		= 'Expire';
 theUILang.FSpassword		= 'Password';
+theUILang.FScreated		= 'Creation date';
 theUILang.FSdlink		= 'Download link';
+theUILang.FSdnumb		= 'Number of downloads';
 theUILang.FSdhours		= 'Duration (hours)';
 theUILang.FSadd			= 'Add';
 theUILang.FSedit		= 'Edit';
@@ -19,4 +23,5 @@ theUILang.FScopylink		= 'Copy link';
 theUILang.FSmaxdur		= 'Maximum allowed duration is:';
 theUILang.FSnolimit		= '[No limit is allowed: 0]';
 theUILang.FSnolimitoff		= 'No limit is not allowed';
+
 thePlugins.get("filemanager-share").langLoaded();

--- a/lang/ko.js
+++ b/lang/ko.js
@@ -1,14 +1,18 @@
 theUILang['flm_popup_flm-create-share'] =   'Create file share link';
 theUILang['flm_popup_fsh-view'] =   'View details';
+theUILang['flm_popup_fsh-view-fm'] =   'Show in File Manager';
 
 theUILang.FSshow		= 'File Share';
+theUILang.FSaddnew		= 'New share';
 theUILang.FSdel			= 'Delete link(s)';
 theUILang.FSdelmsg		= 'Do you really want to delete the selected items?';
 theUILang.FSvdur		= 'Please enter a valid duration';
 theUILang.FSfile		= 'File';
 theUILang.FSexpire		= 'Expire';
 theUILang.FSpassword		= 'Password';
+theUILang.FScreated		= 'Creation date';
 theUILang.FSdlink		= 'Download link';
+theUILang.FSdnumb		= 'Number of downloads';
 theUILang.FSdhours		= 'Duration (hours)';
 theUILang.FSadd			= 'Add';
 theUILang.FSedit		= 'Edit';
@@ -19,4 +23,5 @@ theUILang.FScopylink		= 'Copy link';
 theUILang.FSmaxdur		= 'Maximum allowed duration is:';
 theUILang.FSnolimit		= '[No limit is allowed: 0]';
 theUILang.FSnolimitoff		= 'No limit is not allowed';
+
 thePlugins.get("filemanager-share").langLoaded();

--- a/lang/lv.js
+++ b/lang/lv.js
@@ -1,14 +1,18 @@
 theUILang['flm_popup_flm-create-share'] =   'Create file share link';
 theUILang['flm_popup_fsh-view'] =   'View details';
+theUILang['flm_popup_fsh-view-fm'] =   'Show in File Manager';
 
 theUILang.FSshow		= 'File Share';
+theUILang.FSaddnew		= 'New share';
 theUILang.FSdel			= 'Delete link(s)';
 theUILang.FSdelmsg		= 'Do you really want to delete the selected items?';
 theUILang.FSvdur		= 'Please enter a valid duration';
 theUILang.FSfile		= 'File';
 theUILang.FSexpire		= 'Expire';
 theUILang.FSpassword		= 'Password';
+theUILang.FScreated		= 'Creation date';
 theUILang.FSdlink		= 'Download link';
+theUILang.FSdnumb		= 'Number of downloads';
 theUILang.FSdhours		= 'Duration (hours)';
 theUILang.FSadd			= 'Add';
 theUILang.FSedit		= 'Edit';
@@ -19,4 +23,5 @@ theUILang.FScopylink		= 'Copy link';
 theUILang.FSmaxdur		= 'Maximum allowed duration is:';
 theUILang.FSnolimit		= '[No limit is allowed: 0]';
 theUILang.FSnolimitoff		= 'No limit is not allowed';
+
 thePlugins.get("filemanager-share").langLoaded();

--- a/lang/nl.js
+++ b/lang/nl.js
@@ -1,14 +1,18 @@
 theUILang['flm_popup_flm-create-share'] =   'Create file share link';
 theUILang['flm_popup_fsh-view'] =   'View details';
+theUILang['flm_popup_fsh-view-fm'] =   'Show in File Manager';
 
 theUILang.FSshow		= 'File Share';
+theUILang.FSaddnew		= 'New share';
 theUILang.FSdel			= 'Delete link(s)';
 theUILang.FSdelmsg		= 'Do you really want to delete the selected items?';
 theUILang.FSvdur		= 'Please enter a valid duration';
 theUILang.FSfile		= 'File';
 theUILang.FSexpire		= 'Expire';
 theUILang.FSpassword		= 'Password';
+theUILang.FScreated		= 'Creation date';
 theUILang.FSdlink		= 'Download link';
+theUILang.FSdnumb		= 'Number of downloads';
 theUILang.FSdhours		= 'Duration (hours)';
 theUILang.FSadd			= 'Add';
 theUILang.FSedit		= 'Edit';
@@ -19,4 +23,5 @@ theUILang.FScopylink		= 'Copy link';
 theUILang.FSmaxdur		= 'Maximum allowed duration is:';
 theUILang.FSnolimit		= '[No limit is allowed: 0]';
 theUILang.FSnolimitoff		= 'No limit is not allowed';
+
 thePlugins.get("filemanager-share").langLoaded();

--- a/lang/no.js
+++ b/lang/no.js
@@ -1,14 +1,18 @@
 theUILang['flm_popup_flm-create-share'] =   'Create file share link';
 theUILang['flm_popup_fsh-view'] =   'View details';
+theUILang['flm_popup_fsh-view-fm'] =   'Show in File Manager';
 
 theUILang.FSshow		= 'File Share';
+theUILang.FSaddnew		= 'New share';
 theUILang.FSdel			= 'Delete link(s)';
 theUILang.FSdelmsg		= 'Do you really want to delete the selected items?';
 theUILang.FSvdur		= 'Please enter a valid duration';
 theUILang.FSfile		= 'File';
 theUILang.FSexpire		= 'Expire';
 theUILang.FSpassword		= 'Password';
+theUILang.FScreated		= 'Creation date';
 theUILang.FSdlink		= 'Download link';
+theUILang.FSdnumb		= 'Number of downloads';
 theUILang.FSdhours		= 'Duration (hours)';
 theUILang.FSadd			= 'Add';
 theUILang.FSedit		= 'Edit';
@@ -19,4 +23,5 @@ theUILang.FScopylink		= 'Copy link';
 theUILang.FSmaxdur		= 'Maximum allowed duration is:';
 theUILang.FSnolimit		= '[No limit is allowed: 0]';
 theUILang.FSnolimitoff		= 'No limit is not allowed';
+
 thePlugins.get("filemanager-share").langLoaded();

--- a/lang/pl.js
+++ b/lang/pl.js
@@ -1,14 +1,18 @@
 theUILang['flm_popup_flm-create-share'] =   'Create file share link';
 theUILang['flm_popup_fsh-view'] =   'View details';
+theUILang['flm_popup_fsh-view-fm'] =   'Show in File Manager';
 
 theUILang.FSshow		= 'File Share';
+theUILang.FSaddnew		= 'New share';
 theUILang.FSdel			= 'Delete link(s)';
 theUILang.FSdelmsg		= 'Do you really want to delete the selected items?';
 theUILang.FSvdur		= 'Please enter a valid duration';
 theUILang.FSfile		= 'File';
 theUILang.FSexpire		= 'Expire';
 theUILang.FSpassword		= 'Password';
+theUILang.FScreated		= 'Creation date';
 theUILang.FSdlink		= 'Download link';
+theUILang.FSdnumb		= 'Number of downloads';
 theUILang.FSdhours		= 'Duration (hours)';
 theUILang.FSadd			= 'Add';
 theUILang.FSedit		= 'Edit';
@@ -19,4 +23,5 @@ theUILang.FScopylink		= 'Copy link';
 theUILang.FSmaxdur		= 'Maximum allowed duration is:';
 theUILang.FSnolimit		= '[No limit is allowed: 0]';
 theUILang.FSnolimitoff		= 'No limit is not allowed';
+
 thePlugins.get("filemanager-share").langLoaded();

--- a/lang/pt.js
+++ b/lang/pt.js
@@ -1,14 +1,18 @@
 theUILang['flm_popup_flm-create-share'] =   'Create file share link';
 theUILang['flm_popup_fsh-view'] =   'View details';
+theUILang['flm_popup_fsh-view-fm'] =   'Show in File Manager';
 
 theUILang.FSshow		= 'File Share';
+theUILang.FSaddnew		= 'New share';
 theUILang.FSdel			= 'Delete link(s)';
 theUILang.FSdelmsg		= 'Do you really want to delete the selected items?';
 theUILang.FSvdur		= 'Please enter a valid duration';
 theUILang.FSfile		= 'File';
 theUILang.FSexpire		= 'Expire';
 theUILang.FSpassword		= 'Password';
+theUILang.FScreated		= 'Creation date';
 theUILang.FSdlink		= 'Download link';
+theUILang.FSdnumb		= 'Number of downloads';
 theUILang.FSdhours		= 'Duration (hours)';
 theUILang.FSadd			= 'Add';
 theUILang.FSedit		= 'Edit';
@@ -19,4 +23,5 @@ theUILang.FScopylink		= 'Copy link';
 theUILang.FSmaxdur		= 'Maximum allowed duration is:';
 theUILang.FSnolimit		= '[No limit is allowed: 0]';
 theUILang.FSnolimitoff		= 'No limit is not allowed';
+
 thePlugins.get("filemanager-share").langLoaded();

--- a/lang/ru.js
+++ b/lang/ru.js
@@ -1,14 +1,18 @@
 theUILang['flm_popup_flm-create-share'] =   'Create file share link';
 theUILang['flm_popup_fsh-view'] =   'View details';
+theUILang['flm_popup_fsh-view-fm'] =   'Show in File Manager';
 
 theUILang.FSshow		= 'File Share';
+theUILang.FSaddnew		= 'New share';
 theUILang.FSdel			= 'Delete link(s)';
 theUILang.FSdelmsg		= 'Do you really want to delete the selected items?';
 theUILang.FSvdur		= 'Please enter a valid duration';
 theUILang.FSfile		= 'File';
 theUILang.FSexpire		= 'Expire';
 theUILang.FSpassword		= 'Password';
+theUILang.FScreated		= 'Creation date';
 theUILang.FSdlink		= 'Download link';
+theUILang.FSdnumb		= 'Number of downloads';
 theUILang.FSdhours		= 'Duration (hours)';
 theUILang.FSadd			= 'Add';
 theUILang.FSedit		= 'Edit';
@@ -19,4 +23,5 @@ theUILang.FScopylink		= 'Copy link';
 theUILang.FSmaxdur		= 'Maximum allowed duration is:';
 theUILang.FSnolimit		= '[No limit is allowed: 0]';
 theUILang.FSnolimitoff		= 'No limit is not allowed';
+
 thePlugins.get("filemanager-share").langLoaded();

--- a/lang/sk.js
+++ b/lang/sk.js
@@ -1,14 +1,18 @@
 theUILang['flm_popup_flm-create-share'] =   'Create file share link';
 theUILang['flm_popup_fsh-view'] =   'View details';
+theUILang['flm_popup_fsh-view-fm'] =   'Show in File Manager';
 
 theUILang.FSshow		= 'File Share';
+theUILang.FSaddnew		= 'New share';
 theUILang.FSdel			= 'Delete link(s)';
 theUILang.FSdelmsg		= 'Do you really want to delete the selected items?';
 theUILang.FSvdur		= 'Please enter a valid duration';
 theUILang.FSfile		= 'File';
 theUILang.FSexpire		= 'Expire';
 theUILang.FSpassword		= 'Password';
+theUILang.FScreated		= 'Creation date';
 theUILang.FSdlink		= 'Download link';
+theUILang.FSdnumb		= 'Number of downloads';
 theUILang.FSdhours		= 'Duration (hours)';
 theUILang.FSadd			= 'Add';
 theUILang.FSedit		= 'Edit';
@@ -19,4 +23,5 @@ theUILang.FScopylink		= 'Copy link';
 theUILang.FSmaxdur		= 'Maximum allowed duration is:';
 theUILang.FSnolimit		= '[No limit is allowed: 0]';
 theUILang.FSnolimitoff		= 'No limit is not allowed';
+
 thePlugins.get("filemanager-share").langLoaded();

--- a/lang/sr.js
+++ b/lang/sr.js
@@ -1,14 +1,18 @@
 theUILang['flm_popup_flm-create-share'] =   'Create file share link';
 theUILang['flm_popup_fsh-view'] =   'View details';
+theUILang['flm_popup_fsh-view-fm'] =   'Show in File Manager';
 
 theUILang.FSshow		= 'File Share';
+theUILang.FSaddnew		= 'New share';
 theUILang.FSdel			= 'Delete link(s)';
 theUILang.FSdelmsg		= 'Do you really want to delete the selected items?';
 theUILang.FSvdur		= 'Please enter a valid duration';
 theUILang.FSfile		= 'File';
 theUILang.FSexpire		= 'Expire';
 theUILang.FSpassword		= 'Password';
+theUILang.FScreated		= 'Creation date';
 theUILang.FSdlink		= 'Download link';
+theUILang.FSdnumb		= 'Number of downloads';
 theUILang.FSdhours		= 'Duration (hours)';
 theUILang.FSadd			= 'Add';
 theUILang.FSedit		= 'Edit';
@@ -19,4 +23,5 @@ theUILang.FScopylink		= 'Copy link';
 theUILang.FSmaxdur		= 'Maximum allowed duration is:';
 theUILang.FSnolimit		= '[No limit is allowed: 0]';
 theUILang.FSnolimitoff		= 'No limit is not allowed';
+
 thePlugins.get("filemanager-share").langLoaded();

--- a/lang/sv.js
+++ b/lang/sv.js
@@ -1,14 +1,18 @@
 theUILang['flm_popup_flm-create-share'] =   'Create file share link';
 theUILang['flm_popup_fsh-view'] =   'View details';
+theUILang['flm_popup_fsh-view-fm'] =   'Show in File Manager';
 
 theUILang.FSshow		= 'File Share';
+theUILang.FSaddnew		= 'New share';
 theUILang.FSdel			= 'Delete link(s)';
 theUILang.FSdelmsg		= 'Do you really want to delete the selected items?';
 theUILang.FSvdur		= 'Please enter a valid duration';
 theUILang.FSfile		= 'File';
 theUILang.FSexpire		= 'Expire';
 theUILang.FSpassword		= 'Password';
+theUILang.FScreated		= 'Creation date';
 theUILang.FSdlink		= 'Download link';
+theUILang.FSdnumb		= 'Number of downloads';
 theUILang.FSdhours		= 'Duration (hours)';
 theUILang.FSadd			= 'Add';
 theUILang.FSedit		= 'Edit';
@@ -19,4 +23,5 @@ theUILang.FScopylink		= 'Copy link';
 theUILang.FSmaxdur		= 'Maximum allowed duration is:';
 theUILang.FSnolimit		= '[No limit is allowed: 0]';
 theUILang.FSnolimitoff		= 'No limit is not allowed';
+
 thePlugins.get("filemanager-share").langLoaded();

--- a/lang/tr.js
+++ b/lang/tr.js
@@ -1,14 +1,18 @@
 theUILang['flm_popup_flm-create-share'] =   'Create file share link';
 theUILang['flm_popup_fsh-view'] =   'View details';
+theUILang['flm_popup_fsh-view-fm'] =   'Show in File Manager';
 
 theUILang.FSshow		= 'File Share';
+theUILang.FSaddnew		= 'New share';
 theUILang.FSdel			= 'Delete link(s)';
 theUILang.FSdelmsg		= 'Do you really want to delete the selected items?';
 theUILang.FSvdur		= 'Please enter a valid duration';
 theUILang.FSfile		= 'File';
 theUILang.FSexpire		= 'Expire';
 theUILang.FSpassword		= 'Password';
+theUILang.FScreated		= 'Creation date';
 theUILang.FSdlink		= 'Download link';
+theUILang.FSdnumb		= 'Number of downloads';
 theUILang.FSdhours		= 'Duration (hours)';
 theUILang.FSadd			= 'Add';
 theUILang.FSedit		= 'Edit';
@@ -19,4 +23,5 @@ theUILang.FScopylink		= 'Copy link';
 theUILang.FSmaxdur		= 'Maximum allowed duration is:';
 theUILang.FSnolimit		= '[No limit is allowed: 0]';
 theUILang.FSnolimitoff		= 'No limit is not allowed';
+
 thePlugins.get("filemanager-share").langLoaded();

--- a/lang/uk.js
+++ b/lang/uk.js
@@ -1,14 +1,18 @@
 theUILang['flm_popup_flm-create-share'] =   'Create file share link';
 theUILang['flm_popup_fsh-view'] =   'View details';
+theUILang['flm_popup_fsh-view-fm'] =   'Show in File Manager';
 
 theUILang.FSshow		= 'File Share';
+theUILang.FSaddnew		= 'New share';
 theUILang.FSdel			= 'Delete link(s)';
 theUILang.FSdelmsg		= 'Do you really want to delete the selected items?';
 theUILang.FSvdur		= 'Please enter a valid duration';
 theUILang.FSfile		= 'File';
 theUILang.FSexpire		= 'Expire';
 theUILang.FSpassword		= 'Password';
+theUILang.FScreated		= 'Creation date';
 theUILang.FSdlink		= 'Download link';
+theUILang.FSdnumb		= 'Number of downloads';
 theUILang.FSdhours		= 'Duration (hours)';
 theUILang.FSadd			= 'Add';
 theUILang.FSedit		= 'Edit';
@@ -19,4 +23,5 @@ theUILang.FScopylink		= 'Copy link';
 theUILang.FSmaxdur		= 'Maximum allowed duration is:';
 theUILang.FSnolimit		= '[No limit is allowed: 0]';
 theUILang.FSnolimitoff		= 'No limit is not allowed';
+
 thePlugins.get("filemanager-share").langLoaded();

--- a/lang/vi.js
+++ b/lang/vi.js
@@ -1,14 +1,18 @@
 theUILang['flm_popup_flm-create-share'] =   'Create file share link';
 theUILang['flm_popup_fsh-view'] =   'View details';
+theUILang['flm_popup_fsh-view-fm'] =   'Show in File Manager';
 
 theUILang.FSshow		= 'File Share';
+theUILang.FSaddnew		= 'New share';
 theUILang.FSdel			= 'Delete link(s)';
 theUILang.FSdelmsg		= 'Do you really want to delete the selected items?';
 theUILang.FSvdur		= 'Please enter a valid duration';
 theUILang.FSfile		= 'File';
 theUILang.FSexpire		= 'Expire';
 theUILang.FSpassword		= 'Password';
+theUILang.FScreated		= 'Creation date';
 theUILang.FSdlink		= 'Download link';
+theUILang.FSdnumb		= 'Number of downloads';
 theUILang.FSdhours		= 'Duration (hours)';
 theUILang.FSadd			= 'Add';
 theUILang.FSedit		= 'Edit';
@@ -19,4 +23,5 @@ theUILang.FScopylink		= 'Copy link';
 theUILang.FSmaxdur		= 'Maximum allowed duration is:';
 theUILang.FSnolimit		= '[No limit is allowed: 0]';
 theUILang.FSnolimitoff		= 'No limit is not allowed';
+
 thePlugins.get("filemanager-share").langLoaded();

--- a/lang/zh-cn.js
+++ b/lang/zh-cn.js
@@ -1,14 +1,18 @@
 theUILang['flm_popup_flm-create-share'] =   'Create file share link';
 theUILang['flm_popup_fsh-view'] =   'View details';
+theUILang['flm_popup_fsh-view-fm'] =   'Show in File Manager';
 
 theUILang.FSshow		= 'File Share';
+theUILang.FSaddnew		= 'New share';
 theUILang.FSdel			= 'Delete link(s)';
 theUILang.FSdelmsg		= 'Do you really want to delete the selected items?';
 theUILang.FSvdur		= 'Please enter a valid duration';
 theUILang.FSfile		= 'File';
 theUILang.FSexpire		= 'Expire';
 theUILang.FSpassword		= 'Password';
+theUILang.FScreated		= 'Creation date';
 theUILang.FSdlink		= 'Download link';
+theUILang.FSdnumb		= 'Number of downloads';
 theUILang.FSdhours		= 'Duration (hours)';
 theUILang.FSadd			= 'Add';
 theUILang.FSedit		= 'Edit';
@@ -19,4 +23,5 @@ theUILang.FScopylink		= 'Copy link';
 theUILang.FSmaxdur		= 'Maximum allowed duration is:';
 theUILang.FSnolimit		= '[No limit is allowed: 0]';
 theUILang.FSnolimitoff		= 'No limit is not allowed';
+
 thePlugins.get("filemanager-share").langLoaded();

--- a/lang/zh-tw.js
+++ b/lang/zh-tw.js
@@ -1,14 +1,18 @@
 theUILang['flm_popup_flm-create-share'] =   'Create file share link';
 theUILang['flm_popup_fsh-view'] =   'View details';
+theUILang['flm_popup_fsh-view-fm'] =   'Show in File Manager';
 
 theUILang.FSshow		= 'File Share';
+theUILang.FSaddnew		= 'New share';
 theUILang.FSdel			= 'Delete link(s)';
 theUILang.FSdelmsg		= 'Do you really want to delete the selected items?';
 theUILang.FSvdur		= 'Please enter a valid duration';
 theUILang.FSfile		= 'File';
 theUILang.FSexpire		= 'Expire';
 theUILang.FSpassword		= 'Password';
+theUILang.FScreated		= 'Creation date';
 theUILang.FSdlink		= 'Download link';
+theUILang.FSdnumb		= 'Number of downloads';
 theUILang.FSdhours		= 'Duration (hours)';
 theUILang.FSadd			= 'Add';
 theUILang.FSedit		= 'Edit';
@@ -19,4 +23,5 @@ theUILang.FScopylink		= 'Copy link';
 theUILang.FSmaxdur		= 'Maximum allowed duration is:';
 theUILang.FSnolimit		= '[No limit is allowed: 0]';
 theUILang.FSnolimitoff		= 'No limit is not allowed';
+
 thePlugins.get("filemanager-share").langLoaded();

--- a/plugin.info
+++ b/plugin.info
@@ -1,4 +1,4 @@
-plugin.description: File Manager share plugin
+plugin.description: File Share plugin (an extension for the File Manager plugin).
 plugin.author: HWK
 plugin.version: 1.0
 rtorrent.remote: error

--- a/share.php
+++ b/share.php
@@ -5,19 +5,27 @@ include dirname(__FILE__) . '/boot.php';
 include(dirname(__FILE__) . '/conf.php');
 $config = include('conf.php');
 
-if(!isset($_SERVER['PATH_INFO']))
+if(!isset($_SERVER['PATH_INFO']) || empty($_SERVER['PATH_INFO']))
 {
     die('No such file or it expired');
 }
 
 Crypt::setEncryptionKey($config['key']);
 
-$data = json_decode(Crypt::fromEncoded(trim($_SERVER['PATH_INFO'],'/'))->getString(), true);
+try {
 
-list($user, $token) = $data;
+    $data = json_decode(Crypt::fromEncoded(trim($_SERVER['PATH_INFO'],'/'))->getString(), true);
 
-$_SERVER['REMOTE_USER'] = $user;
+    list($user, $token) = $data;
 
+    $_SERVER['REMOTE_USER'] = $user;
 
-$c = new FileManagerShare(array_merge(Helper::getConfig(), ['share' => $config]));
-$c->downloadFile($token);
+    $c = new FileManagerShare(array_merge(Helper::getConfig(), ['share' => $config]));
+
+    $c->downloadFile($token);
+
+} catch (Exception) {
+
+    die('No such file or it expired');
+
+}

--- a/views/table-header.twig
+++ b/views/table-header.twig
@@ -6,10 +6,8 @@
         <td>
             <a href="javascript:flm.ui.getDialogs().showDialog('flm-create-share');" id="FS_AddNew" class="Button"
 
-            style="padding: 1px 10px; background: #F0F0F0 url(/images/h.gif) repeat-x center bottom; width: 80px; height: 19px; border: 1px solid #A0A0A0; cursor: pointer"
-            >New Share</a>
-        </td>
-        <td><input id="flm-share-clipboard" class="flm-navpath" style="width:100%;display:none; opacity: 0;"/>
+            style="padding: 1px 10px; background: #F0F0F0; width: 80px; height: 19px; border: 1px solid #A0A0A0; cursor: pointer"
+            >{{ theUILang.FSaddnew }}</a>
         </td>
     </tr>
 </table>


### PR DESCRIPTION
- Changed the default `$downloadpath` variable to match the most common ruTorrent installation path
- Used `table` shortcut instead of `theWebUI.getTable("fsh")` when possible
- Used the "copyToClipboard" function recently added in ruTorrent (Novik/ruTorrent#2252)
- Updated/Added needed translations
- Fixed a few things